### PR TITLE
Prove the summing path is linear, and free the bus faders' top +6 dB

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,7 +39,7 @@ work session you can recall being part of, and don't stress over precision.
 ### Claude Opus 5 — Claude Code
 - First seen: 2026-08-21
 - Last seen: 2026-08-28
-- Sessions: 9
+- Sessions: 10
 - Notes: Parameter descriptors, the modulation design, seven effects, the
   mixer bus graph, and the near-term focus sequence. Buffer device stage 1
   follow-up: collision telemetry, debug trigger surface, and the remaining
@@ -57,7 +57,10 @@ work session you can recall being part of, and don't stress over precision.
   legato, velocity accent) and `docs/plans/poly-synth-v2/` (deterministic
   per-voice drift, a multimode filter, grouped unison, an internal chorus).
   Added `scripts/antibox`, which runs builds, tests, and headless UI snapshots
-  on the remote build box instead of the laptop.
+  on the remote build box instead of the laptop. Traced the reported
+  level-dependent summing to a shared nonlinear stage rather than the mixer:
+  added superposition and ducking tests to `gain_structure_tests.rs`, and
+  freed the bus faders' top +6 dB, which the UI was clamping at unity.
 
 ### Claude Sonnet 5 — Claude Code
 - First seen: 2026-08-21

--- a/crates/mooloop-core/src/mixer.rs
+++ b/crates/mooloop-core/src/mixer.rs
@@ -49,7 +49,8 @@ pub enum EffectTarget {
 pub struct MixerBus {
     pub name: String,
     pub muted: bool,
-    /// Linear output volume in [0, 1].
+    /// Linear output volume in [0, `crate::gain::MAX_LINEAR_GAIN`] (+12 dB),
+    /// the same range a channel's gets: a bus is a gain stage too.
     pub volume: f32,
     /// Stereo pan in [-1, 1].
     pub pan: f32,

--- a/crates/mooloop-engine/src/gain_structure_tests.rs
+++ b/crates/mooloop-engine/src/gain_structure_tests.rs
@@ -146,17 +146,15 @@ fn oscillator_summing_gain_matches_today() {
             let mut channel = one_note_channel(kind);
             match kind {
                 DeviceKind::MonoSynth => {
-                    channel.setup.mono_synth_state_mut().unwrap().params = {
-                        let mut params = MonoSynthParams::default();
-                        params.osc = osc_levels(1.0, count);
-                        params
+                    channel.setup.mono_synth_state_mut().unwrap().params = MonoSynthParams {
+                        osc: osc_levels(1.0, count),
+                        ..MonoSynthParams::default()
                     };
                 }
                 DeviceKind::PolySynth => {
-                    channel.setup.poly_synth_state_mut().unwrap().params = {
-                        let mut params = PolySynthParams::default();
-                        params.osc = osc_levels(1.0, count);
-                        params
+                    channel.setup.poly_synth_state_mut().unwrap().params = PolySynthParams {
+                        osc: osc_levels(1.0, count),
+                        ..PolySynthParams::default()
                     };
                 }
                 _ => unreachable!(),

--- a/crates/mooloop-engine/src/gain_structure_tests.rs
+++ b/crates/mooloop-engine/src/gain_structure_tests.rs
@@ -356,13 +356,35 @@ fn pad_and_drums(pad_volume: f32, pad_muted: bool, drums_muted: bool) -> Project
     }
 }
 
+/// Send the pad down a chain of insert buses that ends at the master. A
+/// channel that feeds the master directly never exercises `mix_into`, the
+/// bus-to-bus hop, so the straight-to-master case alone would leave the bus
+/// walk's own summing untested.
+fn route_pad_through(mut project: Project, chain: &[u8]) -> Project {
+    let Some((&first, rest)) = chain.split_first() else {
+        return project;
+    };
+    project.channels[0].setup.channel.bus = first;
+    let mut current = first;
+    for &next in rest {
+        project.buses[current as usize].bus.output = next;
+        current = next;
+    }
+    project.buses[current as usize].bus.output = mooloop_core::MASTER_BUS;
+    project
+}
+
 /// Largest sample-by-sample departure from superposition: how far
 /// `(pad + drums)` rendered together sits from the two rendered apart and
-/// added. Zero for any linear mixer, whatever the faders are set to.
-fn superposition_error(pad_volume: f32) -> (f32, f32) {
-    let (both_l, _) = render_master(&pad_and_drums(pad_volume, false, false), 2.5);
-    let (pad_l, _) = render_master(&pad_and_drums(pad_volume, false, true), 2.5);
-    let (drums_l, _) = render_master(&pad_and_drums(pad_volume, true, false), 2.5);
+/// added. Zero for any linear mixer, whatever the faders are set to and
+/// whatever the pad is routed through.
+fn superposition_error(pad_volume: f32, chain: &[u8]) -> (f32, f32) {
+    let project = |pad_muted, drums_muted| {
+        route_pad_through(pad_and_drums(pad_volume, pad_muted, drums_muted), chain)
+    };
+    let (both_l, _) = render_master(&project(false, false), 2.5);
+    let (pad_l, _) = render_master(&project(false, true), 2.5);
+    let (drums_l, _) = render_master(&project(true, false), 2.5);
     let error = both_l
         .iter()
         .zip(pad_l.iter().zip(drums_l.iter()))
@@ -378,18 +400,22 @@ fn summing_stays_linear_however_the_faders_sit() {
     // scalar were derived from the track gains, moving the pad's fader
     // would change what the drums contribute, and superposition would fail
     // at every fader position but one. Sweep the pad from silence to the
-    // +12 dB ceiling.
-    for pad_volume in [0.0, 0.5, 1.0, 2.0, MAX_LINEAR_GAIN] {
-        let (error, peak) = superposition_error(pad_volume);
-        println!(
-            "pad fader {pad_volume:.2} linear: superposition error {error:.3e} \
-             against a {peak:.3} peak"
-        );
-        assert!(
-            error < 1e-6,
-            "pad fader at {pad_volume} broke superposition by {error:.3e}: \
-             something in the summing path depends on the other track's gain"
-        );
+    // +12 dB ceiling, both straight to the master and down a two-hop bus
+    // chain, so the channel sum and the bus-to-bus sum are both covered.
+    for chain in [&[][..], &[5, 2][..]] {
+        for pad_volume in [0.0, 0.5, 1.0, 2.0, MAX_LINEAR_GAIN] {
+            let (error, peak) = superposition_error(pad_volume, chain);
+            println!(
+                "pad via {chain:?}, fader {pad_volume:.2} linear: \
+                 superposition error {error:.3e} against a {peak:.3} peak"
+            );
+            assert!(
+                error < 1e-6,
+                "pad fader at {pad_volume} via {chain:?} broke superposition by \
+                 {error:.3e}: something in the summing path depends on the \
+                 other track's gain"
+            );
+        }
     }
 }
 

--- a/crates/mooloop-engine/src/gain_structure_tests.rs
+++ b/crates/mooloop-engine/src/gain_structure_tests.rs
@@ -10,9 +10,9 @@
 
 use crate::render::RenderState;
 use mooloop_core::{
-    DeviceKind, DrumMode, EffectKind, EffectParams, EffectSlotState, MonoSynthParams,
+    DeviceKind, DrumMode, EffectKind, EffectParams, EffectSlotState, FilterParams, MonoSynthParams,
     NoteEvent, OscParams, PlateParams, PolySynthParams, Project, ProjectChannel, ReverbParams,
-    SampleReference,
+    SampleReference, MAX_LINEAR_GAIN,
 };
 
 const SAMPLE_RATE: u32 = 48_000;
@@ -288,4 +288,190 @@ fn fader_travel_is_tapered_in_db() {
     // The stored-gain identity is gone: 0.75 linear is no longer what
     // three-quarter travel produces.
     assert!((20.0 * 0.75f32.log10() - -2.5).abs() < 0.05, "sanity");
+}
+
+// --- Level-dependent gain: is the summing path linear? ----------------------
+//
+// Adam's report: raising the pad's fader makes the drums quieter, whatever
+// bus the pad is assigned to. Two categories of cause, and they need
+// different fixes. Control-dependent: something derives a scalar from the
+// track gains (`1.0 / max(gains)` and friends), so moving one fader moves
+// everything. Signal-dependent: something in the shared path reacts to the
+// audio, so a loud pad pushes a drum transient down. The tests below
+// separate them, and they are also the regression fence for the summing
+// contract in `docs/GAIN_STRUCTURE.md`: "no summing point normalizes by its
+// input count".
+
+/// Render the project offline and keep the master's samples, not just its
+/// peak. Superposition can only be checked sample by sample.
+fn render_master(project: &Project, seconds: f32) -> (Vec<f32>, Vec<f32>) {
+    let mut render = RenderState::from_project(SAMPLE_RATE, project, &[]);
+    render.play();
+    let mut remaining = (SAMPLE_RATE as f32 * seconds) as usize;
+    let mut left = Vec::with_capacity(remaining);
+    let mut right = Vec::with_capacity(remaining);
+    while remaining > 0 {
+        let frames = remaining.min(1024);
+        render.process_once_block(frames);
+        let master = render.master();
+        left.extend_from_slice(&master.l[..frames]);
+        right.extend_from_slice(&master.r[..frames]);
+        remaining -= frames;
+    }
+    (left, right)
+}
+
+fn peak_of(samples: &[f32]) -> f32 {
+    samples.iter().fold(0.0f32, |p, s| p.max(s.abs()))
+}
+
+/// A sustained low note: the "pad" whose fader is the one being moved.
+fn pad_channel(volume: f32) -> ProjectChannel {
+    let mut channel = one_note_channel(DeviceKind::PolySynth);
+    channel.setup.channel.volume = volume;
+    // Two seconds at 120 BPM, low enough that its waveform spends most of
+    // each cycle away from zero — the bias a shaper would ride on.
+    channel.notes[0][0] = NoteEvent::new(1, 0, 96 * 4, 40, 127);
+    channel
+}
+
+/// A kick landing a beat in, on top of the pad's sustain.
+fn drum_channel() -> ProjectChannel {
+    let mut channel = one_note_channel(DeviceKind::DrumSynth);
+    channel.notes[0][0].start_tick = 96;
+    channel
+}
+
+/// The pad and the drums together, with either one optionally silenced by
+/// its mute rather than by removing it, so all three renders walk the same
+/// graph.
+fn pad_and_drums(pad_volume: f32, pad_muted: bool, drums_muted: bool) -> Project {
+    let mut pad = pad_channel(pad_volume);
+    pad.setup.channel.muted = pad_muted;
+    let mut drums = drum_channel();
+    drums.setup.channel.muted = drums_muted;
+    Project {
+        channels: vec![pad, drums],
+        ..Project::default()
+    }
+}
+
+/// Largest sample-by-sample departure from superposition: how far
+/// `(pad + drums)` rendered together sits from the two rendered apart and
+/// added. Zero for any linear mixer, whatever the faders are set to.
+fn superposition_error(pad_volume: f32) -> (f32, f32) {
+    let (both_l, _) = render_master(&pad_and_drums(pad_volume, false, false), 2.5);
+    let (pad_l, _) = render_master(&pad_and_drums(pad_volume, false, true), 2.5);
+    let (drums_l, _) = render_master(&pad_and_drums(pad_volume, true, false), 2.5);
+    let error = both_l
+        .iter()
+        .zip(pad_l.iter().zip(drums_l.iter()))
+        .fold(0.0f32, |worst, (both, (pad, drums))| {
+            worst.max((both - pad - drums).abs())
+        });
+    (error, peak_of(&both_l))
+}
+
+#[test]
+fn summing_stays_linear_however_the_faders_sit() {
+    // The control-dependent hypothesis, tested directly: if any headroom
+    // scalar were derived from the track gains, moving the pad's fader
+    // would change what the drums contribute, and superposition would fail
+    // at every fader position but one. Sweep the pad from silence to the
+    // +12 dB ceiling.
+    for pad_volume in [0.0, 0.5, 1.0, 2.0, MAX_LINEAR_GAIN] {
+        let (error, peak) = superposition_error(pad_volume);
+        println!(
+            "pad fader {pad_volume:.2} linear: superposition error {error:.3e} \
+             against a {peak:.3} peak"
+        );
+        assert!(
+            error < 1e-6,
+            "pad fader at {pad_volume} broke superposition by {error:.3e}: \
+             something in the summing path depends on the other track's gain"
+        );
+    }
+}
+
+/// Level of the drums' own contribution over the 50 ms after their onset:
+/// the difference the drum channel makes to the master, in RMS. The window
+/// matters — a nonlinearity's gain swings with the pad's waveform, so a peak
+/// would report the single most favourable instant rather than what is heard.
+fn drum_contribution_db(pad_volume: f32, master: &[EffectSlotState]) -> f32 {
+    let chain = |pad_muted, drums_muted| {
+        let mut project = pad_and_drums(pad_volume, pad_muted, drums_muted);
+        project.buses[0].effects = master.to_vec();
+        project
+    };
+    // The kick lands on beat 2: tick 96 at 120 BPM.
+    let onset = (SAMPLE_RATE / 2) as usize;
+    let window = onset..onset + SAMPLE_RATE as usize / 20;
+    let (both, _) = render_master(&chain(false, false), 2.5);
+    let (pad_only, _) = render_master(&chain(false, true), 2.5);
+    let (drums_only, _) = render_master(&chain(true, false), 2.5);
+    let rms = |samples: &[f32]| {
+        (samples
+            .iter()
+            .map(|s| (*s as f64) * (*s as f64))
+            .sum::<f64>()
+            / samples.len() as f64)
+            .sqrt()
+    };
+    let difference: Vec<f32> = both[window.clone()]
+        .iter()
+        .zip(pad_only[window.clone()].iter())
+        .map(|(both, pad)| both - pad)
+        .collect();
+    20.0 * (rms(&difference).max(1e-12) / rms(&drums_only[window]).max(1e-12)).log10() as f32
+}
+
+#[test]
+fn a_shared_saturation_stage_is_what_ducks_one_track_under_another() {
+    // The signal-dependent hypothesis, and the only mechanism in this
+    // codebase that produces Adam's symptom. `apply_drive` (mooloop-dsp
+    // `filter.rs`) is the one static nonlinearity in the shared path, and
+    // the filter effect carries it, so a filter with drive up on the master
+    // bus sits under everything. A sustained pad then biases the shaper onto
+    // its compressive region and the drum transient riding on top is
+    // multiplied by the local slope. Raising the pad's fader deepens it, and
+    // no bus assignment escapes it, because every bus drains to the master.
+    let driven_filter = |drive: f32| {
+        vec![EffectSlotState::new(EffectParams::Filter(FilterParams {
+            // Wide open: the drive stage is the only thing under test.
+            cutoff_hz: 18_000.0,
+            drive,
+            ..FilterParams::default()
+        }))]
+    };
+
+    // With nothing shared, the pad's fader cannot touch the drums at all —
+    // the same fact `summing_stays_linear_however_the_faders_sit` proves
+    // sample by sample, stated in the terms the symptom was reported in.
+    for pad_volume in [1.0, 2.0, MAX_LINEAR_GAIN] {
+        let clean = drum_contribution_db(pad_volume, &[]);
+        println!("bare master, pad fader {pad_volume:.2}: drums {clean:+.2} dB");
+        assert!(
+            clean.abs() < 0.01,
+            "a bare master moved the drums by {clean:.2} dB at pad fader {pad_volume}"
+        );
+    }
+
+    // With a driven filter on the master, the pad's fader is a ducking
+    // control over the drums.
+    let mut previous = 0.0f32;
+    for pad_volume in [1.0, 2.0, MAX_LINEAR_GAIN] {
+        let ducked = drum_contribution_db(pad_volume, &driven_filter(0.6));
+        println!("master filter at drive 0.6, pad fader {pad_volume:.2}: drums {ducked:+.2} dB");
+        assert!(
+            ducked < previous - 0.1,
+            "pad fader {pad_volume} left the drums at {ducked:+.2} dB, \
+             no deeper than the {previous:+.2} dB of the fader below it"
+        );
+        previous = ducked;
+    }
+    assert!(
+        previous < -2.0,
+        "the deepest duck was only {previous:+.2} dB; the mechanism should be \
+         plainly audible at the +12 dB end of the pad's fader"
+    );
 }

--- a/crates/mooloop-engine/src/gain_structure_tests.rs
+++ b/crates/mooloop-engine/src/gain_structure_tests.rs
@@ -397,10 +397,15 @@ fn summing_stays_linear_however_the_faders_sit() {
 /// the difference the drum channel makes to the master, in RMS. The window
 /// matters — a nonlinearity's gain swings with the pad's waveform, so a peak
 /// would report the single most favourable instant rather than what is heard.
-fn drum_contribution_db(pad_volume: f32, master: &[EffectSlotState]) -> f32 {
+fn drum_contribution_db(
+    pad_volume: f32,
+    master: &[EffectSlotState],
+    pad_channel: &[EffectSlotState],
+) -> f32 {
     let chain = |pad_muted, drums_muted| {
         let mut project = pad_and_drums(pad_volume, pad_muted, drums_muted);
         project.buses[0].effects = master.to_vec();
+        project.channels[0].setup.effects = pad_channel.to_vec();
         project
     };
     // The kick lands on beat 2: tick 96 at 120 BPM.
@@ -448,7 +453,7 @@ fn a_shared_saturation_stage_is_what_ducks_one_track_under_another() {
     // the same fact `summing_stays_linear_however_the_faders_sit` proves
     // sample by sample, stated in the terms the symptom was reported in.
     for pad_volume in [1.0, 2.0, MAX_LINEAR_GAIN] {
-        let clean = drum_contribution_db(pad_volume, &[]);
+        let clean = drum_contribution_db(pad_volume, &[], &[]);
         println!("bare master, pad fader {pad_volume:.2}: drums {clean:+.2} dB");
         assert!(
             clean.abs() < 0.01,
@@ -460,7 +465,7 @@ fn a_shared_saturation_stage_is_what_ducks_one_track_under_another() {
     // control over the drums.
     let mut previous = 0.0f32;
     for pad_volume in [1.0, 2.0, MAX_LINEAR_GAIN] {
-        let ducked = drum_contribution_db(pad_volume, &driven_filter(0.6));
+        let ducked = drum_contribution_db(pad_volume, &driven_filter(0.6), &[]);
         println!("master filter at drive 0.6, pad fader {pad_volume:.2}: drums {ducked:+.2} dB");
         assert!(
             ducked < previous - 0.1,
@@ -474,4 +479,23 @@ fn a_shared_saturation_stage_is_what_ducks_one_track_under_another() {
         "the deepest duck was only {previous:+.2} dB; the mechanism should be \
          plainly audible at the +12 dB end of the pad's fader"
     );
+
+    // Placement is the whole mechanism, not the effect. The same filter at
+    // the same drive on the pad's own channel runs on the pad's buffer
+    // before anything is summed (`RenderState::process_block`: the chain
+    // processes `strip.bus`, and only then is it added into the destination
+    // bus), so it cannot reach the drums however hard the pad is driven
+    // into it.
+    for pad_volume in [1.0, 2.0, MAX_LINEAR_GAIN] {
+        let on_the_channel = drum_contribution_db(pad_volume, &[], &driven_filter(0.6));
+        println!(
+            "pad-channel filter at drive 0.6, pad fader {pad_volume:.2}: \
+             drums {on_the_channel:+.2} dB"
+        );
+        assert!(
+            on_the_channel.abs() < 0.01,
+            "a filter on the pad's own channel moved the drums by \
+             {on_the_channel:+.2} dB at pad fader {pad_volume}"
+        );
+    }
 }

--- a/crates/mooloop-project/src/lib.rs
+++ b/crates/mooloop-project/src/lib.rs
@@ -1634,6 +1634,11 @@ id = "default_kick"
             .sample = SampleReference::Builtin {
             id: "default_kick".into(),
         };
+        // The manifest stores the pre-reference-level default of 0.8, which
+        // the loader must honor rather than replace with today's unity
+        // default. Asserting it here is the point: a stored gain survives a
+        // change to what a fresh channel starts at.
+        expected.channels[0].setup.channel.volume = 0.8;
         assert_eq!(loaded, expected);
         assert_eq!(loaded.buses.len(), mooloop_core::MAX_BUSES);
         assert_eq!(

--- a/crates/mooloop-ui/src/lib.rs
+++ b/crates/mooloop-ui/src/lib.rs
@@ -5360,7 +5360,10 @@ impl AppUi {
                 let Ok(index) = usize::try_from(bus) else {
                     return;
                 };
-                let volume = volume.clamp(0.0, 1.0);
+                // The bus fader's throw reaches +6 dB and the engine's
+                // output stage accepts +12, same as a channel's: clamping
+                // here at unity left the top of every bus fader dead.
+                let volume = volume.clamp(0.0, MAX_LINEAR_GAIN);
                 let mut guard = st.borrow_mut();
                 let Some(setup) = guard.buses.get_mut(index) else {
                     return;

--- a/docs/GAIN_STRUCTURE.md
+++ b/docs/GAIN_STRUCTURE.md
@@ -53,7 +53,18 @@ same device on a channel touches nothing else.
 `a_shared_saturation_stage_is_what_ducks_one_track_under_another` measures
 both: a filter at drive 0.6 on the master pulls the drums down 4.7 dB as the
 pad's fader travels from unity to +12, and the same filter on the pad's own
-channel moves them 0.00 dB.
+channel moves them 0.00 dB. The bus walk itself adds nothing either: the
+same superposition holds with the pad routed down a two-hop insert chain,
+which is what puts audio through `mix_into`.
+
+**Nothing bounds a sample in the live path.** The engine's only writes into
+a bus buffer are the effect container's input trim, its wet/dry blend and
+output trim, the dry-path delay ring, and `StereoBus`'s add and multiply —
+every one of them linear in the signal. The single place a sample is
+clipped anywhere in the codebase is `pcm24`, in
+`mooloop-engine/src/offline.rs`: that is the 24-bit WAV encoder, so exports
+hard-clip at full scale and live playback does not. Sums above 0 dBFS reach
+the output device intact, and pulling them down is the user's business.
 
 **Per-oscillator unity reference.** A synth oscillator's 0 dB knob position
 *is* the device reference: one oscillator at full peaks at

--- a/docs/GAIN_STRUCTURE.md
+++ b/docs/GAIN_STRUCTURE.md
@@ -36,6 +36,21 @@ unity (`MixerBus::new`), buses sum into the master at unity. With the
 operating level, eight identical channels peak near +6 dBFS — inside the
 +12 dB clamp, audible, and the user's problem, not the engine's.
 
+**No fader touches another track.** The whole summing path is linear: a
+channel's gain and pan, `StereoBus::add_from`, and the bus walk in
+`RenderState::process_block` are all plain multiply-and-add, so rendering
+two channels together gives exactly what rendering them apart and adding
+gives, at every fader position. `summing_stays_linear_however_the_faders_sit`
+holds that sample by sample up to the +12 dB ceiling. If one track ever
+appears to duck another, nothing in the summing path can be responsible;
+look for a shared *nonlinear* stage instead — a driven filter, the drive
+effect, a compressor or limiter on a bus every source drains through. Those
+are level-dependent by design, they have no time constant when the shaper is
+static, and no bus assignment escapes one sitting on the master.
+`a_shared_saturation_stage_is_what_ducks_one_track_under_another` measures
+it: a filter at drive 0.6 on the master pulls the drums down 4.7 dB as the
+pad's fader travels from unity to +12.
+
 **Per-oscillator unity reference.** A synth oscillator's 0 dB knob position
 *is* the device reference: one oscillator at full peaks at
 `REFERENCE_PEAK_DBFS`, three at full sum honestly to about -2.4 dBFS. The

--- a/docs/GAIN_STRUCTURE.md
+++ b/docs/GAIN_STRUCTURE.md
@@ -47,9 +47,13 @@ look for a shared *nonlinear* stage instead — a driven filter, the drive
 effect, a compressor or limiter on a bus every source drains through. Those
 are level-dependent by design, they have no time constant when the shaper is
 static, and no bus assignment escapes one sitting on the master.
+What matters is placement, not the effect: a channel's chain runs on that
+channel's own buffer and is only then added into its destination bus, so the
+same device on a channel touches nothing else.
 `a_shared_saturation_stage_is_what_ducks_one_track_under_another` measures
-it: a filter at drive 0.6 on the master pulls the drums down 4.7 dB as the
-pad's fader travels from unity to +12.
+both: a filter at drive 0.6 on the master pulls the drums down 4.7 dB as the
+pad's fader travels from unity to +12, and the same filter on the pad's own
+channel moves them 0.00 dB.
 
 **Per-oscillator unity reference.** A synth oscillator's 0 dB knob position
 *is* the device reference: one oscillator at full peaks at


### PR DESCRIPTION
## What this is

An investigation, not a bug fix. The reported symptom — raising one track's
fader making other tracks quieter — does not reproduce in the engine, and did
not reproduce for the author on a fresh build either. What this branch leaves
behind is the proof of that, plus two real and unrelated fixes found on the way.

## The summing path is linear

`summing_stays_linear_however_the_faders_sit` renders a pad and a drum hit
together, then each alone, and compares sample by sample. Superposition error
stays at float rounding — 3e-8 at worst against a ~1.0 peak — across the pad's
whole fader throw from silence to the +12 dB ceiling, and again with the pad
routed down a two-hop insert chain so the bus-to-bus hop (`mix_into`) carries
audio rather than being skipped. No summing point derives anything from another
track's gain; there is no headroom scalar to find.

## What can actually cause the symptom

`a_shared_saturation_stage_is_what_ducks_one_track_under_another` measures the
one mechanism that can: a *nonlinear* stage on a shared bus. A filter at drive
0.6 on the master pulls the drums down 0.34 / 2.23 / 4.68 dB as the pad's fader
travels unity → +6 → +12. The same filter at the same drive on the pad's own
channel moves them 0.00 dB, because a channel's chain runs on that channel's
buffer and is only then added into its destination bus.

Placement is the mechanism, not the effect. This is inherent to saturating a
sum — it is what a console or tape does — not a defect in the mixer.

## Fix 1: bus faders were clamped at unity

`on_bus_volume_changed` clamped bus volume to `1.0`, while the gain-structure
plan's step 04 gave the bus fader a +6 dB throw and the engine's output stage
accepts +12, same as a channel's. The top of every bus fader, master included,
was dead and snapped back on release. It now clamps to `MAX_LINEAR_GAIN`,
matching the channel handler, and the stale `[0, 1]` doc on `MixerBus::volume`
is corrected.

## Fix 2: `cargo test --workspace` was red on `main`

Two failures predating this branch, both ported in here so the merge isn't
blocked on them. Each no-ops once `main` carries the same change.

- `mooloop-project`'s `legacy_sampler_source_shape_remains_loadable` compared a
  legacy manifest storing `volume = 0.8` against `Project::default()`, which
  `cdd5450` moved to unity. Verified red on `origin/main` at `f85fc69` in a
  separate worktree. Fixed by asserting the stored `0.8` survives — rewriting
  the fixture to `1.0` would have deleted the guarantee the test exists for.
- Two `clippy::field_reassign_with_default` errors in `gain_structure_tests.rs`
  (from `4ab5cf8`), which failed `cargo clippy --workspace --all-targets -- -D
  warnings`.

## Also in here

`docs/GAIN_STRUCTURE.md` records the linear-summing guarantee, the placement
rule, the enumerated list of every write the engine makes into a bus buffer
(all linear), and the fact that the only place a sample is clipped anywhere in
the codebase is `pcm24`, the 24-bit WAV encoder — so exports hard-clip at full
scale where live playback does not.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmsGoRsUUpyp9ZeXDN6inS